### PR TITLE
Refactored Code To Calculate All Number Of Priority Groups

### DIFF
--- a/Wait_Times_Math_Model/QueueWaitTimes.html
+++ b/Wait_Times_Math_Model/QueueWaitTimes.html
@@ -14609,7 +14609,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">P_GROUP_BOUNDS</span> <span class="o">=</span> <span class="p">[</span><span class="mi">1</span><span class="p">,</span><span class="mi">3</span><span class="p">,</span><span class="mi">10</span><span class="p">]</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">P_GROUP_SIZE</span> <span class="o">=</span> <span class="mi">4</span>
 
 <span class="n">COLS_TO_USE</span> <span class="o">=</span> <span class="p">[</span><span class="mi">4</span><span class="p">,</span><span class="mi">5</span><span class="p">,</span><span class="mi">6</span><span class="p">,</span><span class="mi">9</span><span class="p">,</span><span class="mi">10</span><span class="p">,</span><span class="mi">12</span><span class="p">,</span><span class="mi">13</span><span class="p">,</span><span class="mi">14</span><span class="p">,</span><span class="mi">15</span><span class="p">,</span><span class="mi">16</span><span class="p">]</span>
 <span class="n">HEADER_NAMES</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;size&#39;</span><span class="p">,</span><span class="s1">&#39;weight&#39;</span><span class="p">,</span><span class="s1">&#39;received_time&#39;</span><span class="p">,</span><span class="s1">&#39;fee&#39;</span><span class="p">,</span><span class="s1">&#39;confirmed_block_height&#39;</span><span class="p">,</span><span class="s1">&#39;confirm_time&#39;</span><span class="p">,</span><span class="s1">&#39;waiting_time&#39;</span><span class="p">,</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">,</span><span class="s1">&#39;enter_block_height&#39;</span><span class="p">,</span><span class="s1">&#39;no_block_confirm&#39;</span><span class="p">]</span>
@@ -14646,7 +14646,6 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 
 <span class="n">dataFrame</span> <span class="o">=</span> <span class="n">dataFrame</span><span class="p">[</span><span class="n">dataFrame</span><span class="p">[</span><span class="s1">&#39;waiting_time&#39;</span><span class="p">]</span> <span class="o">&gt;=</span> <span class="mi">0</span><span class="p">]</span> <span class="c1"># Remove any rows with negative values for waiting_time</span>
 <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Transaction Count: &quot;</span><span class="p">,</span> <span class="nb">len</span><span class="p">(</span><span class="n">dataFrame</span><span class="p">))</span>
-<span class="c1">#dataFrame.head(10)</span>
 </pre></div>
 
      </div>
@@ -14736,7 +14735,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 </div>
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
-<h3 id="Fee-Rate-Priority-Range">Fee Rate Priority Range<a class="anchor-link" href="#Fee-Rate-Priority-Range">&#182;</a></h3>
+<h3 id="Service-Rate-(Mu)">Service Rate (Mu)<a class="anchor-link" href="#Service-Rate-(Mu)">&#182;</a></h3>
 </div>
 </div>
 </div>
@@ -14748,20 +14747,10 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="k">def</span> <span class="nf">calculate_feerate_for_priority_groups</span><span class="p">(</span><span class="n">data</span><span class="p">,</span> <span class="n">upper_boundary</span><span class="p">):</span>
-    <span class="n">feerate_range</span> <span class="o">=</span> <span class="p">[]</span>
-    <span class="n">transaction_counts</span> <span class="o">=</span> <span class="mi">0</span>
-    <span class="n">feerate_range</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">data</span><span class="p">[</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">max</span><span class="p">())</span>
-    <span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">P_GROUP_BOUNDS</span><span class="p">)):</span>
-        <span class="n">transaction_counts</span> <span class="o">=</span> <span class="nb">len</span><span class="p">(</span><span class="n">data</span><span class="p">[</span><span class="n">data</span><span class="p">[</span><span class="s1">&#39;no_block_confirm&#39;</span><span class="p">]</span> <span class="o">&lt;=</span> <span class="n">upper_boundary</span><span class="p">[</span><span class="n">i</span><span class="p">]])</span>
-        <span class="c1">#boundary = data[&#39;fee_rate&#39;].nlargest(transaction_counts).iloc[-1]</span>
-        <span class="n">boundary</span> <span class="o">=</span> <span class="n">data</span><span class="p">[</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">tail</span><span class="p">(</span><span class="n">transaction_counts</span><span class="p">)</span><span class="o">.</span><span class="n">iloc</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-        <span class="n">feerate_range</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">boundary</span><span class="p">)</span>
-    <span class="k">return</span> <span class="n">feerate_range</span>
-
-<span class="n">p_groups_feerate_range</span> <span class="o">=</span> <span class="n">calculate_feerate_for_priority_groups</span><span class="p">(</span><span class="n">dataFrame</span><span class="o">.</span><span class="n">sort_values</span><span class="p">(</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">),</span> <span class="n">P_GROUP_BOUNDS</span><span class="p">)</span>
-<span class="n">p_groups_feerate_range</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="mf">0.0</span><span class="p">)</span>
-<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Fee Rate Priority Range: &quot;</span><span class="p">,</span> <span class="n">p_groups_feerate_range</span><span class="p">)</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">service_time</span> <span class="o">=</span> <span class="mi">600</span>
+<span class="n">mu</span> <span class="o">=</span> <span class="mi">1</span><span class="o">/</span><span class="n">service_time</span> <span class="c1"># = 0.0016666666666666668</span>
+<span class="c1">#mu = (1/service_time)*mean_block_size # = 3.776666666666667</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Mu: &quot;</span><span class="p">,</span> <span class="n">mu</span><span class="p">)</span>
 </pre></div>
 
      </div>
@@ -14783,7 +14772,105 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Fee Rate Priority Range:  [52380.95238095238, 30.175438596491237, 18.529411764705888, 5.0, 0.0]
+<pre>Mu:  0.0016666666666666668
+</pre>
+</div>
+</div>
+
+</div>
+
+</div>
+
+</div>
+<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
+</div>
+<div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
+</div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
+<h3 id="Priority-Group-Bounds-(Block-Intervals)">Priority Group Bounds (Block Intervals)<a class="anchor-link" href="#Priority-Group-Bounds-(Block-Intervals)">&#182;</a></h3>
+</div>
+</div>
+</div>
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
+</div>
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="k">def</span> <span class="nf">calculate_block_intervals</span><span class="p">(</span><span class="n">num_groups</span><span class="p">):</span>
+    <span class="k">match</span> <span class="n">num_groups</span><span class="p">:</span>
+        <span class="k">case</span> <span class="mi">2</span><span class="p">:</span> <span class="k">return</span> <span class="p">[</span><span class="mi">1</span><span class="p">]</span>
+        <span class="k">case</span> <span class="mi">4</span><span class="p">:</span> <span class="k">return</span> <span class="p">[</span><span class="mi">1</span><span class="p">,</span><span class="mi">3</span><span class="p">,</span><span class="mi">10</span><span class="p">]</span>
+        <span class="k">case</span> <span class="mi">6</span><span class="p">:</span> <span class="k">return</span> <span class="p">[</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">,</span><span class="mi">4</span><span class="p">,</span><span class="mi">8</span><span class="p">,</span><span class="mi">23</span><span class="p">]</span>
+        <span class="k">case</span> <span class="mi">8</span><span class="p">:</span> <span class="k">return</span> <span class="p">[</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">,</span><span class="mi">4</span><span class="p">,</span><span class="mi">7</span><span class="p">,</span><span class="mi">13</span><span class="p">,</span><span class="mi">23</span><span class="p">,</span><span class="mi">50</span><span class="p">]</span>
+        <span class="k">case</span> <span class="k">_</span><span class="p">:</span> <span class="k">return</span> <span class="p">[</span><span class="mi">1</span><span class="p">,</span><span class="mi">3</span><span class="p">,</span><span class="mi">10</span><span class="p">]</span>
+
+<span class="n">block_intervals</span> <span class="o">=</span> <span class="n">calculate_block_intervals</span><span class="p">(</span><span class="n">P_GROUP_SIZE</span><span class="p">)</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+</div>
+<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
+</div>
+<div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
+</div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
+<h3 id="Priority-Group-Range-(Fee-Rate)">Priority Group Range (Fee Rate)<a class="anchor-link" href="#Priority-Group-Range-(Fee-Rate)">&#182;</a></h3>
+</div>
+</div>
+</div>
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
+</div>
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="k">def</span> <span class="nf">calculate_feerate_for_priority_groups</span><span class="p">(</span><span class="n">data</span><span class="p">,</span> <span class="n">upper_boundary</span><span class="p">):</span>
+    <span class="n">feerate_range</span> <span class="o">=</span> <span class="p">[]</span>
+    <span class="n">transaction_counts</span> <span class="o">=</span> <span class="mi">0</span>
+    <span class="n">feerate_range</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">data</span><span class="p">[</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">max</span><span class="p">())</span>
+    <span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">upper_boundary</span><span class="p">)):</span>
+        <span class="n">transaction_counts</span> <span class="o">=</span> <span class="nb">len</span><span class="p">(</span><span class="n">data</span><span class="p">[</span><span class="n">data</span><span class="p">[</span><span class="s1">&#39;no_block_confirm&#39;</span><span class="p">]</span> <span class="o">&lt;=</span> <span class="n">upper_boundary</span><span class="p">[</span><span class="n">i</span><span class="p">]])</span>
+        <span class="c1">#boundary = data[&#39;fee_rate&#39;].nlargest(transaction_counts).iloc[-1]</span>
+        <span class="n">boundary</span> <span class="o">=</span> <span class="n">data</span><span class="p">[</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">tail</span><span class="p">(</span><span class="n">transaction_counts</span><span class="p">)</span><span class="o">.</span><span class="n">iloc</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+        <span class="n">feerate_range</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">boundary</span><span class="p">)</span>
+    <span class="k">return</span> <span class="n">feerate_range</span>
+
+<span class="n">p_groups_feerate_range</span> <span class="o">=</span> <span class="n">calculate_feerate_for_priority_groups</span><span class="p">(</span><span class="n">dataFrame</span><span class="o">.</span><span class="n">sort_values</span><span class="p">(</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">),</span> <span class="n">block_intervals</span><span class="p">)</span>
+<span class="n">p_groups_feerate_range</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="mf">0.0</span><span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Priority Group Range (Fee Rate): &quot;</span><span class="p">,</span> <span class="n">p_groups_feerate_range</span><span class="p">)</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+<div class="jp-Cell-outputWrapper">
+<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
+</div>
+
+
+<div class="jp-OutputArea jp-Cell-outputArea">
+
+<div class="jp-OutputArea-child">
+
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Priority Group Range (Fee Rate):  [52380.95238095238, 30.175438596491237, 18.529411764705888, 5.0, 0.0]
 </pre>
 </div>
 </div>
@@ -14820,7 +14907,6 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <span class="k">for</span> <span class="n">current</span><span class="p">,</span> <span class="nb">next</span> <span class="ow">in</span> <span class="nb">zip</span><span class="p">(</span><span class="n">p_groups_feerate_range</span><span class="p">,</span><span class="n">p_groups_feerate_range</span><span class="p">[</span><span class="mi">1</span><span class="p">:]):</span>
     <span class="n">p_df</span> <span class="o">=</span> <span class="n">dataFrame</span><span class="p">[(</span><span class="n">dataFrame</span><span class="p">[</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">]</span> <span class="o">&lt;=</span> <span class="n">current</span><span class="p">)</span> <span class="o">&amp;</span> <span class="p">(</span><span class="n">dataFrame</span><span class="p">[</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">]</span> <span class="o">&gt;</span> <span class="nb">next</span><span class="p">)]</span>
     <span class="n">p_transaction_count</span> <span class="o">=</span> <span class="nb">len</span><span class="p">(</span><span class="n">p_df</span><span class="p">)</span>
-    <span class="c1">#p_lambda = float(p_transaction_count) / (float(p_df[&#39;received_time&#39;].max()) - float(p_df[&#39;received_time&#39;].min()))</span>
     <span class="n">p_lambda</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="n">p_transaction_count</span><span class="p">)</span> <span class="o">/</span> <span class="p">(</span><span class="n">received_time_max</span> <span class="o">-</span> <span class="n">received_time_min</span><span class="p">)</span>
     <span class="n">p_groups_lambda</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">p_lambda</span><span class="p">)</span>
     <span class="n">raw_wait_times</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">p_df</span><span class="p">[</span><span class="s1">&#39;waiting_time&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">mean</span><span class="p">())</span>
@@ -14870,59 +14956,6 @@ Feerate Min: 0.907563025210084, Max: 5.0
 Lambda: 0.36567295193583804
 
 Sum Of All Lambda:  3.083224253031129
-</pre>
-</div>
-</div>
-
-</div>
-
-</div>
-
-</div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
-<div class="jp-Cell-inputWrapper">
-<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
-</div>
-<div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
-</div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
-<h3 id="Service-Rate-(Mu)">Service Rate (Mu)<a class="anchor-link" href="#Service-Rate-(Mu)">&#182;</a></h3>
-</div>
-</div>
-</div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
-<div class="jp-Cell-inputWrapper">
-<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
-</div>
-<div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
-<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-     <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">service_time</span> <span class="o">=</span> <span class="mi">600</span>
-<span class="n">mu</span> <span class="o">=</span> <span class="mi">1</span><span class="o">/</span><span class="n">service_time</span> <span class="c1"># = 0.0016666666666666668</span>
-<span class="c1">#mu = (1/service_time)*mean_block_size # = 3.776666666666667</span>
-<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Mu: &quot;</span><span class="p">,</span> <span class="n">mu</span><span class="p">)</span>
-</pre></div>
-
-     </div>
-</div>
-</div>
-</div>
-
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-
-
-<div class="jp-OutputArea jp-Cell-outputArea">
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Mu:  0.0016666666666666668
 </pre>
 </div>
 </div>
@@ -15043,9 +15076,6 @@ My Z: 0.9998145619120352, SciPy Z: 0.9998145619140734
     <span class="n">temp</span> <span class="o">=</span> <span class="n">sciPy_p_group_z</span><span class="p">[</span><span class="n">i</span><span class="p">]</span> <span class="o">/</span> <span class="p">(</span><span class="mi">1</span> <span class="o">-</span> <span class="n">sciPy_p_group_z</span><span class="p">[</span><span class="n">i</span><span class="p">])</span> <span class="c1"># L(y) = z(x) / (1 - z(x))</span>
     <span class="n">transaction_in_queue</span> <span class="o">=</span> <span class="n">temp</span> <span class="o">-</span> <span class="n">prev_transaction_in_queue</span> <span class="c1"># L(x) = L(y) - L(y-1)</span>
     <span class="n">prev_transaction_in_queue</span> <span class="o">=</span> <span class="n">temp</span>
-    
-    <span class="c1">#transaction_in_queue = my_p_group_z[i] / (1 - my_p_group_z[i]) - prev_transaction_in_queue # L(x) = (z(x) / (1 - z(x))) - L(x-1)</span>
-    <span class="c1">#prev_transaction_in_queue = transaction_in_queue</span>
 
     <span class="n">response_time</span> <span class="o">=</span> <span class="n">transaction_in_queue</span> <span class="o">/</span> <span class="n">p_groups_lambda</span><span class="p">[</span><span class="n">i</span><span class="p">]</span> <span class="c1"># W(x) = L(x) / Lambda(x)</span>
 

--- a/Wait_Times_Math_Model/QueueWaitTimes.html
+++ b/Wait_Times_Math_Model/QueueWaitTimes.html
@@ -15167,7 +15167,10 @@ Average Response Time In Queue (W): 5872.883583023225
     <span class="k">return</span> <span class="n">P_GROUP_WAITING_TIMES</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="n">num_of_priorities</span><span class="p">)</span>
 
 <span class="n">P_GROUP_WAITING_TIMES</span> <span class="o">=</span> <span class="n">initialise_values</span><span class="p">(</span><span class="n">dataFrame</span><span class="p">,</span> <span class="n">P_GROUP_BLOCK_INTERVAL_DICTIONARY</span><span class="p">)</span>
-<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Wait Times For 2 Priority Groups:&quot;</span><span class="p">,</span> <span class="n">Get_Wait_Times_Based_On_Num_Of_Priorities</span><span class="p">(</span><span class="mi">4</span><span class="p">))</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Wait Times For 2 Priority Groups:&quot;</span><span class="p">,</span> <span class="n">Get_Wait_Times_Based_On_Num_Of_Priorities</span><span class="p">(</span><span class="mi">2</span><span class="p">))</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Wait Times For 4 Priority Groups:&quot;</span><span class="p">,</span> <span class="n">Get_Wait_Times_Based_On_Num_Of_Priorities</span><span class="p">(</span><span class="mi">4</span><span class="p">))</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Wait Times For 6 Priority Groups:&quot;</span><span class="p">,</span> <span class="n">Get_Wait_Times_Based_On_Num_Of_Priorities</span><span class="p">(</span><span class="mi">6</span><span class="p">))</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Wait Times For 8 Priority Groups:&quot;</span><span class="p">,</span> <span class="n">Get_Wait_Times_Based_On_Num_Of_Priorities</span><span class="p">(</span><span class="mi">8</span><span class="p">))</span>
 </pre></div>
 
      </div>
@@ -15189,7 +15192,10 @@ Average Response Time In Queue (W): 5872.883583023225
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Wait Times For 2 Priority Groups: [743.4900615259027, 1638.8303977947135, 2917.0059775136638, 5872.883583023225]
+<pre>Wait Times For 2 Priority Groups: [743.4900615259027, 3260.7014455515123]
+Wait Times For 4 Priority Groups: [743.4900615259027, 1638.8303977947135, 2917.0059775136638, 5872.883583023225]
+Wait Times For 6 Priority Groups: [743.4900615259027, 1482.7163201834983, 2145.484056944325, 3003.95895361719, 4277.576084859145, 6811.416797072625]
+Wait Times For 8 Priority Groups: [743.4900615259027, 1482.7163201834983, 2145.484056944325, 2920.2290929531323, 3793.455068134325, 4734.751333144836, 5808.567123895104, 7624.408084316089]
 </pre>
 </div>
 </div>

--- a/Wait_Times_Math_Model/QueueWaitTimes.html
+++ b/Wait_Times_Math_Model/QueueWaitTimes.html
@@ -14610,6 +14610,13 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">P_GROUP_SIZE</span> <span class="o">=</span> <span class="mi">4</span>
+<span class="n">P_GROUP_BLOCK_INTERVAL_DICTIONARY</span> <span class="o">=</span> <span class="p">{</span>
+    <span class="mi">2</span> <span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="p">],</span>
+    <span class="mi">4</span> <span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="p">,</span><span class="mi">3</span><span class="p">,</span><span class="mi">10</span><span class="p">],</span>
+    <span class="mi">6</span> <span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">,</span><span class="mi">4</span><span class="p">,</span><span class="mi">8</span><span class="p">,</span><span class="mi">23</span><span class="p">],</span>
+    <span class="mi">8</span> <span class="p">:</span> <span class="p">[</span><span class="mi">1</span><span class="p">,</span><span class="mi">2</span><span class="p">,</span><span class="mi">4</span><span class="p">,</span><span class="mi">7</span><span class="p">,</span><span class="mi">13</span><span class="p">,</span><span class="mi">23</span><span class="p">,</span><span class="mi">50</span><span class="p">]</span>
+<span class="p">}</span>
+<span class="n">P_GROUP_WAITING_TIMES</span> <span class="o">=</span> <span class="p">{}</span>
 
 <span class="n">COLS_TO_USE</span> <span class="o">=</span> <span class="p">[</span><span class="mi">4</span><span class="p">,</span><span class="mi">5</span><span class="p">,</span><span class="mi">6</span><span class="p">,</span><span class="mi">9</span><span class="p">,</span><span class="mi">10</span><span class="p">,</span><span class="mi">12</span><span class="p">,</span><span class="mi">13</span><span class="p">,</span><span class="mi">14</span><span class="p">,</span><span class="mi">15</span><span class="p">,</span><span class="mi">16</span><span class="p">]</span>
 <span class="n">HEADER_NAMES</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;size&#39;</span><span class="p">,</span><span class="s1">&#39;weight&#39;</span><span class="p">,</span><span class="s1">&#39;received_time&#39;</span><span class="p">,</span><span class="s1">&#39;fee&#39;</span><span class="p">,</span><span class="s1">&#39;confirmed_block_height&#39;</span><span class="p">,</span><span class="s1">&#39;confirm_time&#39;</span><span class="p">,</span><span class="s1">&#39;waiting_time&#39;</span><span class="p">,</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">,</span><span class="s1">&#39;enter_block_height&#39;</span><span class="p">,</span><span class="s1">&#39;no_block_confirm&#39;</span><span class="p">]</span>
@@ -14683,7 +14690,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 </div>
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
-<h3 id="Block-Size">Block Size<a class="anchor-link" href="#Block-Size">&#182;</a></h3>
+<h3 id="Block-Size-&amp;-Service-Rate-(Mu)">Block Size &amp; Service Rate (Mu)<a class="anchor-link" href="#Block-Size-&amp;-Service-Rate-(Mu)">&#182;</a></h3>
 </div>
 </div>
 </div>
@@ -14697,59 +14704,10 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">block_groups</span> <span class="o">=</span> <span class="n">dataFrame</span><span class="o">.</span><span class="n">groupby</span><span class="p">([</span><span class="s1">&#39;confirmed_block_height&#39;</span><span class="p">])[</span><span class="s1">&#39;confirmed_block_height&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">count</span><span class="p">()</span>
 <span class="n">mean_block_size</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="nb">round</span><span class="p">(</span><span class="n">block_groups</span><span class="o">.</span><span class="n">mean</span><span class="p">()))</span>
-<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Mean Block Size: &quot;</span><span class="p">,</span> <span class="n">mean_block_size</span><span class="p">)</span>
-</pre></div>
-
-     </div>
-</div>
-</div>
-</div>
-
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-
-
-<div class="jp-OutputArea jp-Cell-outputArea">
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Mean Block Size:  2266.0
-</pre>
-</div>
-</div>
-
-</div>
-
-</div>
-
-</div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
-<div class="jp-Cell-inputWrapper">
-<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
-</div>
-<div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
-</div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
-<h3 id="Service-Rate-(Mu)">Service Rate (Mu)<a class="anchor-link" href="#Service-Rate-(Mu)">&#182;</a></h3>
-</div>
-</div>
-</div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
-<div class="jp-Cell-inputWrapper">
-<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
-</div>
-<div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
-<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-     <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">service_time</span> <span class="o">=</span> <span class="mi">600</span>
+<span class="n">service_time</span> <span class="o">=</span> <span class="mi">600</span>
 <span class="n">mu</span> <span class="o">=</span> <span class="mi">1</span><span class="o">/</span><span class="n">service_time</span> <span class="c1"># = 0.0016666666666666668</span>
 <span class="c1">#mu = (1/service_time)*mean_block_size # = 3.776666666666667</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Mean Block Size: &quot;</span><span class="p">,</span> <span class="n">mean_block_size</span><span class="p">)</span>
 <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Mu: &quot;</span><span class="p">,</span> <span class="n">mu</span><span class="p">)</span>
 </pre></div>
 
@@ -14772,7 +14730,8 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Mu:  0.0016666666666666668
+<pre>Mean Block Size:  2266.0
+Mu:  0.0016666666666666668
 </pre>
 </div>
 </div>
@@ -14792,7 +14751,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -14809,11 +14768,35 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
         <span class="k">case</span> <span class="k">_</span><span class="p">:</span> <span class="k">return</span> <span class="p">[</span><span class="mi">1</span><span class="p">,</span><span class="mi">3</span><span class="p">,</span><span class="mi">10</span><span class="p">]</span>
 
 <span class="n">block_intervals</span> <span class="o">=</span> <span class="n">calculate_block_intervals</span><span class="p">(</span><span class="n">P_GROUP_SIZE</span><span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Block Intervals:&quot;</span><span class="p">,</span> <span class="n">block_intervals</span><span class="p">)</span>
 </pre></div>
 
      </div>
 </div>
 </div>
+</div>
+
+<div class="jp-Cell-outputWrapper">
+<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
+</div>
+
+
+<div class="jp-OutputArea jp-Cell-outputArea">
+
+<div class="jp-OutputArea-child">
+
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Block Intervals: [1, 3, 10]
+</pre>
+</div>
+</div>
+
+</div>
+
 </div>
 
 </div>
@@ -14844,10 +14827,10 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
         <span class="c1">#boundary = data[&#39;fee_rate&#39;].nlargest(transaction_counts).iloc[-1]</span>
         <span class="n">boundary</span> <span class="o">=</span> <span class="n">data</span><span class="p">[</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">tail</span><span class="p">(</span><span class="n">transaction_counts</span><span class="p">)</span><span class="o">.</span><span class="n">iloc</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
         <span class="n">feerate_range</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">boundary</span><span class="p">)</span>
+    <span class="n">feerate_range</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="mf">0.0</span><span class="p">)</span>
     <span class="k">return</span> <span class="n">feerate_range</span>
 
 <span class="n">p_groups_feerate_range</span> <span class="o">=</span> <span class="n">calculate_feerate_for_priority_groups</span><span class="p">(</span><span class="n">dataFrame</span><span class="o">.</span><span class="n">sort_values</span><span class="p">(</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">),</span> <span class="n">block_intervals</span><span class="p">)</span>
-<span class="n">p_groups_feerate_range</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="mf">0.0</span><span class="p">)</span>
 <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Priority Group Range (Fee Rate): &quot;</span><span class="p">,</span> <span class="n">p_groups_feerate_range</span><span class="p">)</span>
 </pre></div>
 
@@ -14898,7 +14881,18 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">raw_wait_times</span> <span class="o">=</span> <span class="p">[]</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="k">def</span> <span class="nf">calculate_lambda_for_priority_groups</span><span class="p">(</span><span class="n">data</span><span class="p">,</span> <span class="n">feerate_range</span><span class="p">):</span>
+    <span class="n">p_groups_lambda</span> <span class="o">=</span> <span class="p">[]</span>
+    <span class="n">received_time_max</span> <span class="o">=</span> <span class="n">data</span><span class="p">[</span><span class="s1">&#39;received_time&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">max</span><span class="p">()</span>
+    <span class="n">received_time_min</span> <span class="o">=</span> <span class="n">data</span><span class="p">[</span><span class="s1">&#39;received_time&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">min</span><span class="p">()</span>
+    <span class="k">for</span> <span class="n">current</span><span class="p">,</span> <span class="nb">next</span> <span class="ow">in</span> <span class="nb">zip</span><span class="p">(</span><span class="n">feerate_range</span><span class="p">,</span><span class="n">feerate_range</span><span class="p">[</span><span class="mi">1</span><span class="p">:]):</span>
+        <span class="n">p_df</span> <span class="o">=</span> <span class="n">data</span><span class="p">[(</span><span class="n">data</span><span class="p">[</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">]</span> <span class="o">&lt;=</span> <span class="n">current</span><span class="p">)</span> <span class="o">&amp;</span> <span class="p">(</span><span class="n">data</span><span class="p">[</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">]</span> <span class="o">&gt;</span> <span class="nb">next</span><span class="p">)]</span>
+        <span class="n">p_transaction_count</span> <span class="o">=</span> <span class="nb">len</span><span class="p">(</span><span class="n">p_df</span><span class="p">)</span>
+        <span class="n">p_lambda</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="n">p_transaction_count</span><span class="p">)</span> <span class="o">/</span> <span class="p">(</span><span class="n">received_time_max</span> <span class="o">-</span> <span class="n">received_time_min</span><span class="p">)</span>
+        <span class="n">p_groups_lambda</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">p_lambda</span><span class="p">)</span>
+    <span class="k">return</span> <span class="n">p_groups_lambda</span>
+
+<span class="n">raw_wait_times</span> <span class="o">=</span> <span class="p">[]</span>
 <span class="n">p_groups_lambda</span> <span class="o">=</span> <span class="p">[]</span>
 <span class="n">transaction_count</span> <span class="o">=</span> <span class="nb">len</span><span class="p">(</span><span class="n">dataFrame</span><span class="p">)</span>
 <span class="n">received_time_max</span> <span class="o">=</span> <span class="n">dataFrame</span><span class="p">[</span><span class="s1">&#39;received_time&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">max</span><span class="p">()</span>
@@ -14983,11 +14977,7 @@ Sum Of All Lambda:  3.083224253031129
 <div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">my_p_group_z</span> <span class="o">=</span> <span class="p">[]</span>
-<span class="n">sciPy_p_group_z</span> <span class="o">=</span> <span class="p">[]</span>
-<span class="n">lambda_sum</span> <span class="o">=</span> <span class="mf">0.0</span>
-
-<span class="k">def</span> <span class="nf">NewtonMethod</span><span class="p">(</span><span class="n">lam</span><span class="p">,</span> <span class="n">m_u</span><span class="p">,</span> <span class="n">block_size</span><span class="p">,</span> <span class="n">x0</span><span class="p">,</span> <span class="n">epsilon</span><span class="p">):</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="k">def</span> <span class="nf">NewtonMethod</span><span class="p">(</span><span class="n">lam</span><span class="p">,</span> <span class="n">m_u</span><span class="p">,</span> <span class="n">block_size</span><span class="p">,</span> <span class="n">x0</span><span class="p">,</span> <span class="n">epsilon</span><span class="p">):</span>
     <span class="n">fx</span> <span class="o">=</span> <span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">lam</span><span class="o">*</span><span class="p">(</span><span class="mi">1</span> <span class="o">-</span> <span class="n">x</span><span class="p">)</span> <span class="o">-</span> <span class="n">m_u</span><span class="o">*</span><span class="n">x</span><span class="o">*</span><span class="p">(</span><span class="mi">1</span> <span class="o">-</span> <span class="n">x</span><span class="o">**</span><span class="n">block_size</span><span class="p">)</span>
     <span class="n">dfx</span> <span class="o">=</span> <span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">m_u</span><span class="o">*</span><span class="p">(</span><span class="n">block_size</span><span class="o">*</span><span class="n">x</span><span class="o">**</span><span class="n">block_size</span> <span class="o">+</span> <span class="n">x</span><span class="o">**</span><span class="n">block_size</span> <span class="o">-</span> <span class="mi">1</span><span class="p">)</span> <span class="o">-</span> <span class="n">lam</span>
     <span class="k">while</span> <span class="kc">True</span><span class="p">:</span>
@@ -15003,6 +14993,21 @@ Sum Of All Lambda:  3.083224253031129
     <span class="c1">#dfx = lambda x: m_u*(block_size*x**block_size + x**block_size - 1) - lam</span>
     <span class="c1">#return newton(fx, x0, fprime=dfx, args=(), tol=epsilon, maxiter=max_iteration, fprime2=None)</span>
     <span class="k">return</span> <span class="n">newton</span><span class="p">(</span><span class="n">fx</span><span class="p">,</span> <span class="n">x0</span><span class="p">,</span> <span class="n">fprime</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">args</span><span class="o">=</span><span class="p">(),</span> <span class="n">tol</span><span class="o">=</span><span class="n">epsilon</span><span class="p">,</span> <span class="n">maxiter</span><span class="o">=</span><span class="n">max_iteration</span><span class="p">,</span> <span class="n">fprime2</span><span class="o">=</span><span class="kc">None</span><span class="p">)</span>
+
+<span class="k">def</span> <span class="nf">calculate_z_priority</span><span class="p">(</span><span class="n">lambda_priority_group</span><span class="p">,</span> <span class="n">m_u</span><span class="p">,</span> <span class="n">block_size</span><span class="p">):</span>
+    <span class="n">my_p_group_z</span> <span class="o">=</span> <span class="p">[]</span>
+    <span class="n">sciPy_p_group_z</span> <span class="o">=</span> <span class="p">[]</span>
+    <span class="n">lambda_sum</span> <span class="o">=</span> <span class="mf">0.0</span>
+    <span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">lambda_priority_group</span><span class="p">)):</span>
+        <span class="n">lambda_sum</span> <span class="o">+=</span> <span class="n">lambda_priority_group</span><span class="p">[</span><span class="n">i</span><span class="p">]</span>
+        <span class="n">my_p_group_z</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">NewtonMethod</span><span class="p">(</span><span class="n">lambda_sum</span><span class="p">,</span> <span class="n">m_u</span><span class="p">,</span> <span class="n">block_size</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">1e-10</span><span class="p">))</span>
+        <span class="n">sciPy_p_group_z</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">SciPyNewton</span><span class="p">(</span><span class="n">lambda_sum</span><span class="p">,</span> <span class="n">m_u</span><span class="p">,</span> <span class="n">block_size</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">1e-10</span><span class="p">,</span> <span class="mi">500</span><span class="p">))</span>
+    <span class="c1">#return my_p_group_z</span>
+    <span class="k">return</span> <span class="n">sciPy_p_group_z</span>
+    
+<span class="n">my_p_group_z</span> <span class="o">=</span> <span class="p">[]</span>
+<span class="n">sciPy_p_group_z</span> <span class="o">=</span> <span class="p">[]</span>
+<span class="n">lambda_sum</span> <span class="o">=</span> <span class="mf">0.0</span>
 
 <span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">p_groups_lambda</span><span class="p">)):</span>
     <span class="n">lambda_sum</span> <span class="o">+=</span> <span class="n">p_groups_lambda</span><span class="p">[</span><span class="n">i</span><span class="p">]</span>
@@ -15069,7 +15074,18 @@ My Z: 0.9998145619120352, SciPy Z: 0.9998145619140734
 <div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">prev_transaction_in_queue</span> <span class="o">=</span> <span class="mf">0.0</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="k">def</span> <span class="nf">calculate_wait_time_for_priority_groups</span><span class="p">(</span><span class="n">p_group_lambda</span><span class="p">,</span> <span class="n">p_group_z</span><span class="p">):</span>
+    <span class="n">prev_transaction_in_queue</span> <span class="o">=</span> <span class="mf">0.0</span>
+    <span class="n">p_group_response_time</span> <span class="o">=</span> <span class="p">[]</span>
+    <span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">p_group_lambda</span><span class="p">)):</span>
+        <span class="n">temp</span> <span class="o">=</span> <span class="n">p_group_z</span><span class="p">[</span><span class="n">i</span><span class="p">]</span> <span class="o">/</span> <span class="p">(</span><span class="mi">1</span> <span class="o">-</span> <span class="n">p_group_z</span><span class="p">[</span><span class="n">i</span><span class="p">])</span> <span class="c1"># L(y) = z(x) / (1 - z(x))</span>
+        <span class="n">transaction_in_queue</span> <span class="o">=</span> <span class="n">temp</span> <span class="o">-</span> <span class="n">prev_transaction_in_queue</span> <span class="c1"># L(x) = L(y) - L(y-1)</span>
+        <span class="n">prev_transaction_in_queue</span> <span class="o">=</span> <span class="n">temp</span>
+        <span class="n">response_time</span> <span class="o">=</span> <span class="n">transaction_in_queue</span> <span class="o">/</span> <span class="n">p_group_lambda</span><span class="p">[</span><span class="n">i</span><span class="p">]</span> <span class="c1"># W(x) = L(x) / Lambda(x)</span>
+        <span class="n">p_group_response_time</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">response_time</span><span class="p">)</span>
+    <span class="k">return</span> <span class="n">p_group_response_time</span>
+
+<span class="n">prev_transaction_in_queue</span> <span class="o">=</span> <span class="mf">0.0</span>
 <span class="n">p_group_response_time</span> <span class="o">=</span> <span class="p">[]</span>
 
 <span class="k">for</span> <span class="n">i</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">p_groups_lambda</span><span class="p">)):</span>
@@ -15117,6 +15133,63 @@ Average Response Time In Queue (W): 2917.0059775136638
 Priority Group 4
 Average Transaction In Queue (L):  2147.554676179624
 Average Response Time In Queue (W): 5872.883583023225
+</pre>
+</div>
+</div>
+
+</div>
+
+</div>
+
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
+<div class="jp-Cell-inputWrapper">
+<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
+</div>
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[&nbsp;]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+     <div class="CodeMirror cm-s-jupyter">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="k">def</span> <span class="nf">initialise_values</span><span class="p">(</span><span class="n">data</span><span class="p">,</span> <span class="n">block_intervals</span><span class="p">):</span>
+    <span class="n">p_group_wait_time</span> <span class="o">=</span> <span class="p">{}</span>
+    <span class="n">block_group</span> <span class="o">=</span> <span class="n">data</span><span class="o">.</span><span class="n">groupby</span><span class="p">([</span><span class="s1">&#39;confirmed_block_height&#39;</span><span class="p">])[</span><span class="s1">&#39;confirmed_block_height&#39;</span><span class="p">]</span><span class="o">.</span><span class="n">count</span><span class="p">()</span>
+    <span class="n">average_block_size</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="nb">round</span><span class="p">(</span><span class="n">block_group</span><span class="o">.</span><span class="n">mean</span><span class="p">()))</span>
+    <span class="n">s_time</span> <span class="o">=</span> <span class="mi">600</span>
+    <span class="n">m_u</span> <span class="o">=</span> <span class="mi">1</span><span class="o">/</span><span class="n">s_time</span> <span class="c1"># = 0.0016666666666666668</span>
+    <span class="k">for</span> <span class="n">key</span><span class="p">,</span> <span class="n">value</span> <span class="ow">in</span> <span class="n">block_intervals</span><span class="o">.</span><span class="n">items</span><span class="p">():</span>
+        <span class="n">feerate_range</span> <span class="o">=</span> <span class="n">calculate_feerate_for_priority_groups</span><span class="p">(</span><span class="n">data</span><span class="o">.</span><span class="n">sort_values</span><span class="p">(</span><span class="s1">&#39;fee_rate&#39;</span><span class="p">),</span> <span class="n">value</span><span class="p">)</span>
+        <span class="n">p_lambda</span> <span class="o">=</span> <span class="n">calculate_lambda_for_priority_groups</span><span class="p">(</span><span class="n">data</span><span class="p">,</span> <span class="n">feerate_range</span><span class="p">)</span>
+        <span class="n">p_z</span> <span class="o">=</span> <span class="n">calculate_z_priority</span><span class="p">(</span><span class="n">p_lambda</span><span class="p">,</span> <span class="n">m_u</span><span class="p">,</span> <span class="n">average_block_size</span><span class="p">)</span>
+        <span class="n">p_wait_time</span> <span class="o">=</span> <span class="n">calculate_wait_time_for_priority_groups</span><span class="p">(</span><span class="n">p_lambda</span><span class="p">,</span> <span class="n">p_z</span><span class="p">)</span>
+        <span class="n">p_group_wait_time</span><span class="p">[</span><span class="n">key</span><span class="p">]</span> <span class="o">=</span> <span class="n">p_wait_time</span>
+    <span class="k">return</span> <span class="n">p_group_wait_time</span>
+
+<span class="k">def</span> <span class="nf">Get_Wait_Times_Based_On_Num_Of_Priorities</span><span class="p">(</span><span class="n">num_of_priorities</span><span class="p">):</span>
+    <span class="k">return</span> <span class="n">P_GROUP_WAITING_TIMES</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="n">num_of_priorities</span><span class="p">)</span>
+
+<span class="n">P_GROUP_WAITING_TIMES</span> <span class="o">=</span> <span class="n">initialise_values</span><span class="p">(</span><span class="n">dataFrame</span><span class="p">,</span> <span class="n">P_GROUP_BLOCK_INTERVAL_DICTIONARY</span><span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Wait Times For 2 Priority Groups:&quot;</span><span class="p">,</span> <span class="n">Get_Wait_Times_Based_On_Num_Of_Priorities</span><span class="p">(</span><span class="mi">4</span><span class="p">))</span>
+</pre></div>
+
+     </div>
+</div>
+</div>
+</div>
+
+<div class="jp-Cell-outputWrapper">
+<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
+</div>
+
+
+<div class="jp-OutputArea jp-Cell-outputArea">
+
+<div class="jp-OutputArea-child">
+
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Wait Times For 2 Priority Groups: [743.4900615259027, 1638.8303977947135, 2917.0059775136638, 5872.883583023225]
 </pre>
 </div>
 </div>

--- a/Wait_Times_Math_Model/QueueWaitTimes.ipynb
+++ b/Wait_Times_Math_Model/QueueWaitTimes.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -248,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -372,14 +372,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wait Times For 2 Priority Groups: [743.4900615259027, 1638.8303977947135, 2917.0059775136638, 5872.883583023225]\n"
+      "Wait Times For 2 Priority Groups: [743.4900615259027, 3260.7014455515123]\n",
+      "Wait Times For 4 Priority Groups: [743.4900615259027, 1638.8303977947135, 2917.0059775136638, 5872.883583023225]\n",
+      "Wait Times For 6 Priority Groups: [743.4900615259027, 1482.7163201834983, 2145.484056944325, 3003.95895361719, 4277.576084859145, 6811.416797072625]\n",
+      "Wait Times For 8 Priority Groups: [743.4900615259027, 1482.7163201834983, 2145.484056944325, 2920.2290929531323, 3793.455068134325, 4734.751333144836, 5808.567123895104, 7624.408084316089]\n"
      ]
     }
    ],
@@ -402,7 +405,10 @@
     "    return P_GROUP_WAITING_TIMES.get(num_of_priorities)\n",
     "\n",
     "P_GROUP_WAITING_TIMES = initialise_values(dataFrame, P_GROUP_BLOCK_INTERVAL_DICTIONARY)\n",
-    "print(\"Wait Times For 2 Priority Groups:\", Get_Wait_Times_Based_On_Num_Of_Priorities(4))"
+    "print(\"Wait Times For 2 Priority Groups:\", Get_Wait_Times_Based_On_Num_Of_Priorities(2))\n",
+    "print(\"Wait Times For 4 Priority Groups:\", Get_Wait_Times_Based_On_Num_Of_Priorities(4))\n",
+    "print(\"Wait Times For 6 Priority Groups:\", Get_Wait_Times_Based_On_Num_Of_Priorities(6))\n",
+    "print(\"Wait Times For 8 Priority Groups:\", Get_Wait_Times_Based_On_Num_Of_Priorities(8))"
    ]
   }
  ],

--- a/Wait_Times_Math_Model/QueueWaitTimes.ipynb
+++ b/Wait_Times_Math_Model/QueueWaitTimes.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,11 +21,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
-    "P_GROUP_BOUNDS = [1,3,10]\n",
+    "P_GROUP_SIZE = 4\n",
     "\n",
     "COLS_TO_USE = [4,5,6,9,10,12,13,14,15,16]\n",
     "HEADER_NAMES = ['size','weight','received_time','fee','confirmed_block_height','confirm_time','waiting_time','fee_rate','enter_block_height','no_block_confirm']"
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -58,8 +58,7 @@
     "dataFrame = pandas.concat([d1, d2, d3])\n",
     "\n",
     "dataFrame = dataFrame[dataFrame['waiting_time'] >= 0] # Remove any rows with negative values for waiting_time\n",
-    "print(\"Transaction Count: \", len(dataFrame))\n",
-    "#dataFrame.head(10)"
+    "print(\"Transaction Count: \", len(dataFrame))"
    ]
   },
   {
@@ -71,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -92,19 +91,70 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Fee Rate Priority Range"
+    "### Service Rate (Mu)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Fee Rate Priority Range:  [52380.95238095238, 30.175438596491237, 18.529411764705888, 5.0, 0.0]\n"
+      "Mu:  0.0016666666666666668\n"
+     ]
+    }
+   ],
+   "source": [
+    "service_time = 600\n",
+    "mu = 1/service_time # = 0.0016666666666666668\n",
+    "#mu = (1/service_time)*mean_block_size # = 3.776666666666667\n",
+    "print(\"Mu: \", mu)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Priority Group Bounds (Block Intervals)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calculate_block_intervals(num_groups):\n",
+    "    match num_groups:\n",
+    "        case 2: return [1]\n",
+    "        case 4: return [1,3,10]\n",
+    "        case 6: return [1,2,4,8,23]\n",
+    "        case 8: return [1,2,4,7,13,23,50]\n",
+    "        case _: return [1,3,10]\n",
+    "\n",
+    "block_intervals = calculate_block_intervals(P_GROUP_SIZE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Priority Group Range (Fee Rate)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Priority Group Range (Fee Rate):  [52380.95238095238, 30.175438596491237, 18.529411764705888, 5.0, 0.0]\n"
      ]
     }
    ],
@@ -113,16 +163,16 @@
     "    feerate_range = []\n",
     "    transaction_counts = 0\n",
     "    feerate_range.append(data['fee_rate'].max())\n",
-    "    for i in range(len(P_GROUP_BOUNDS)):\n",
+    "    for i in range(len(upper_boundary)):\n",
     "        transaction_counts = len(data[data['no_block_confirm'] <= upper_boundary[i]])\n",
     "        #boundary = data['fee_rate'].nlargest(transaction_counts).iloc[-1]\n",
     "        boundary = data['fee_rate'].tail(transaction_counts).iloc[0]\n",
     "        feerate_range.append(boundary)\n",
     "    return feerate_range\n",
     "\n",
-    "p_groups_feerate_range = calculate_feerate_for_priority_groups(dataFrame.sort_values('fee_rate'), P_GROUP_BOUNDS)\n",
+    "p_groups_feerate_range = calculate_feerate_for_priority_groups(dataFrame.sort_values('fee_rate'), block_intervals)\n",
     "p_groups_feerate_range.append(0.0)\n",
-    "print(\"Fee Rate Priority Range: \", p_groups_feerate_range)"
+    "print(\"Priority Group Range (Fee Rate): \", p_groups_feerate_range)"
    ]
   },
   {
@@ -134,7 +184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
@@ -172,7 +222,6 @@
     "for current, next in zip(p_groups_feerate_range,p_groups_feerate_range[1:]):\n",
     "    p_df = dataFrame[(dataFrame['fee_rate'] <= current) & (dataFrame['fee_rate'] > next)]\n",
     "    p_transaction_count = len(p_df)\n",
-    "    #p_lambda = float(p_transaction_count) / (float(p_df['received_time'].max()) - float(p_df['received_time'].min()))\n",
     "    p_lambda = float(p_transaction_count) / (received_time_max - received_time_min)\n",
     "    p_groups_lambda.append(p_lambda)\n",
     "    raw_wait_times.append(p_df['waiting_time'].mean())\n",
@@ -189,39 +238,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Service Rate (Mu)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 54,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mu:  0.0016666666666666668\n"
-     ]
-    }
-   ],
-   "source": [
-    "service_time = 600\n",
-    "mu = 1/service_time # = 0.0016666666666666668\n",
-    "#mu = (1/service_time)*mean_block_size # = 3.776666666666667\n",
-    "print(\"Mu: \", mu)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Validation Of Z Using Newton Method (Mine Vs SciPy)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
@@ -281,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
@@ -311,9 +333,6 @@
     "    temp = sciPy_p_group_z[i] / (1 - sciPy_p_group_z[i]) # L(y) = z(x) / (1 - z(x))\n",
     "    transaction_in_queue = temp - prev_transaction_in_queue # L(x) = L(y) - L(y-1)\n",
     "    prev_transaction_in_queue = temp\n",
-    "    \n",
-    "    #transaction_in_queue = my_p_group_z[i] / (1 - my_p_group_z[i]) - prev_transaction_in_queue # L(x) = (z(x) / (1 - z(x))) - L(x-1)\n",
-    "    #prev_transaction_in_queue = transaction_in_queue\n",
     "\n",
     "    response_time = transaction_in_queue / p_groups_lambda[i] # W(x) = L(x) / Lambda(x)\n",
     "\n",

--- a/Wait_Times_Math_Model/QueueWaitTimes.ipynb
+++ b/Wait_Times_Math_Model/QueueWaitTimes.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,11 +21,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
     "P_GROUP_SIZE = 4\n",
+    "P_GROUP_BLOCK_INTERVAL_DICTIONARY = {\n",
+    "    2 : [1],\n",
+    "    4 : [1,3,10],\n",
+    "    6 : [1,2,4,8,23],\n",
+    "    8 : [1,2,4,7,13,23,50]\n",
+    "}\n",
+    "P_GROUP_WAITING_TIMES = {}\n",
     "\n",
     "COLS_TO_USE = [4,5,6,9,10,12,13,14,15,16]\n",
     "HEADER_NAMES = ['size','weight','received_time','fee','confirmed_block_height','confirm_time','waiting_time','fee_rate','enter_block_height','no_block_confirm']"
@@ -40,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -65,52 +72,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Block Size"
+    "### Block Size & Service Rate (Mu)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mean Block Size:  2266.0\n"
+      "Mean Block Size:  2266.0\n",
+      "Mu:  0.0016666666666666668\n"
      ]
     }
    ],
    "source": [
     "block_groups = dataFrame.groupby(['confirmed_block_height'])['confirmed_block_height'].count()\n",
     "mean_block_size = float(round(block_groups.mean()))\n",
-    "print(\"Mean Block Size: \", mean_block_size)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Service Rate (Mu)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 51,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mu:  0.0016666666666666668\n"
-     ]
-    }
-   ],
-   "source": [
     "service_time = 600\n",
     "mu = 1/service_time # = 0.0016666666666666668\n",
     "#mu = (1/service_time)*mean_block_size # = 3.776666666666667\n",
+    "print(\"Mean Block Size: \", mean_block_size)\n",
     "print(\"Mu: \", mu)"
    ]
   },
@@ -123,9 +108,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Block Intervals: [1, 3, 10]\n"
+     ]
+    }
+   ],
    "source": [
     "def calculate_block_intervals(num_groups):\n",
     "    match num_groups:\n",
@@ -135,7 +128,8 @@
     "        case 8: return [1,2,4,7,13,23,50]\n",
     "        case _: return [1,3,10]\n",
     "\n",
-    "block_intervals = calculate_block_intervals(P_GROUP_SIZE)"
+    "block_intervals = calculate_block_intervals(P_GROUP_SIZE)\n",
+    "print(\"Block Intervals:\", block_intervals)"
    ]
   },
   {
@@ -147,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -168,10 +162,10 @@
     "        #boundary = data['fee_rate'].nlargest(transaction_counts).iloc[-1]\n",
     "        boundary = data['fee_rate'].tail(transaction_counts).iloc[0]\n",
     "        feerate_range.append(boundary)\n",
+    "    feerate_range.append(0.0)\n",
     "    return feerate_range\n",
     "\n",
     "p_groups_feerate_range = calculate_feerate_for_priority_groups(dataFrame.sort_values('fee_rate'), block_intervals)\n",
-    "p_groups_feerate_range.append(0.0)\n",
     "print(\"Priority Group Range (Fee Rate): \", p_groups_feerate_range)"
    ]
   },
@@ -184,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -213,6 +207,17 @@
     }
    ],
    "source": [
+    "def calculate_lambda_for_priority_groups(data, feerate_range):\n",
+    "    p_groups_lambda = []\n",
+    "    received_time_max = data['received_time'].max()\n",
+    "    received_time_min = data['received_time'].min()\n",
+    "    for current, next in zip(feerate_range,feerate_range[1:]):\n",
+    "        p_df = data[(data['fee_rate'] <= current) & (data['fee_rate'] > next)]\n",
+    "        p_transaction_count = len(p_df)\n",
+    "        p_lambda = float(p_transaction_count) / (received_time_max - received_time_min)\n",
+    "        p_groups_lambda.append(p_lambda)\n",
+    "    return p_groups_lambda\n",
+    "\n",
     "raw_wait_times = []\n",
     "p_groups_lambda = []\n",
     "transaction_count = len(dataFrame)\n",
@@ -243,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -262,10 +267,6 @@
     }
    ],
    "source": [
-    "my_p_group_z = []\n",
-    "sciPy_p_group_z = []\n",
-    "lambda_sum = 0.0\n",
-    "\n",
     "def NewtonMethod(lam, m_u, block_size, x0, epsilon):\n",
     "    fx = lambda x: lam*(1 - x) - m_u*x*(1 - x**block_size)\n",
     "    dfx = lambda x: m_u*(block_size*x**block_size + x**block_size - 1) - lam\n",
@@ -282,6 +283,21 @@
     "    #dfx = lambda x: m_u*(block_size*x**block_size + x**block_size - 1) - lam\n",
     "    #return newton(fx, x0, fprime=dfx, args=(), tol=epsilon, maxiter=max_iteration, fprime2=None)\n",
     "    return newton(fx, x0, fprime=None, args=(), tol=epsilon, maxiter=max_iteration, fprime2=None)\n",
+    "\n",
+    "def calculate_z_priority(lambda_priority_group, m_u, block_size):\n",
+    "    my_p_group_z = []\n",
+    "    sciPy_p_group_z = []\n",
+    "    lambda_sum = 0.0\n",
+    "    for i in range(len(lambda_priority_group)):\n",
+    "        lambda_sum += lambda_priority_group[i]\n",
+    "        my_p_group_z.append(NewtonMethod(lambda_sum, m_u, block_size, 0, 1e-10))\n",
+    "        sciPy_p_group_z.append(SciPyNewton(lambda_sum, m_u, block_size, 0, 1e-10, 500))\n",
+    "    #return my_p_group_z\n",
+    "    return sciPy_p_group_z\n",
+    "    \n",
+    "my_p_group_z = []\n",
+    "sciPy_p_group_z = []\n",
+    "lambda_sum = 0.0\n",
     "\n",
     "for i in range(len(p_groups_lambda)):\n",
     "    lambda_sum += p_groups_lambda[i]\n",
@@ -303,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -326,6 +342,17 @@
     }
    ],
    "source": [
+    "def calculate_wait_time_for_priority_groups(p_group_lambda, p_group_z):\n",
+    "    prev_transaction_in_queue = 0.0\n",
+    "    p_group_response_time = []\n",
+    "    for i in range(len(p_group_lambda)):\n",
+    "        temp = p_group_z[i] / (1 - p_group_z[i]) # L(y) = z(x) / (1 - z(x))\n",
+    "        transaction_in_queue = temp - prev_transaction_in_queue # L(x) = L(y) - L(y-1)\n",
+    "        prev_transaction_in_queue = temp\n",
+    "        response_time = transaction_in_queue / p_group_lambda[i] # W(x) = L(x) / Lambda(x)\n",
+    "        p_group_response_time.append(response_time)\n",
+    "    return p_group_response_time\n",
+    "\n",
     "prev_transaction_in_queue = 0.0\n",
     "p_group_response_time = []\n",
     "\n",
@@ -340,7 +367,42 @@
     "\n",
     "    print(\"Priority Group \" + str(i+1))\n",
     "    print(\"Average Transaction In Queue (L): \", transaction_in_queue)\n",
-    "    print(\"Average Response Time In Queue (W): \" + str(response_time))"
+    "    print(\"Average Response Time In Queue (W): \" + str(response_time))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wait Times For 2 Priority Groups: [743.4900615259027, 1638.8303977947135, 2917.0059775136638, 5872.883583023225]\n"
+     ]
+    }
+   ],
+   "source": [
+    "def initialise_values(data, block_intervals):\n",
+    "    p_group_wait_time = {}\n",
+    "    block_group = data.groupby(['confirmed_block_height'])['confirmed_block_height'].count()\n",
+    "    average_block_size = float(round(block_group.mean()))\n",
+    "    s_time = 600\n",
+    "    m_u = 1/s_time # = 0.0016666666666666668\n",
+    "    for key, value in block_intervals.items():\n",
+    "        feerate_range = calculate_feerate_for_priority_groups(data.sort_values('fee_rate'), value)\n",
+    "        p_lambda = calculate_lambda_for_priority_groups(data, feerate_range)\n",
+    "        p_z = calculate_z_priority(p_lambda, m_u, average_block_size)\n",
+    "        p_wait_time = calculate_wait_time_for_priority_groups(p_lambda, p_z)\n",
+    "        p_group_wait_time[key] = p_wait_time\n",
+    "    return p_group_wait_time\n",
+    "\n",
+    "def Get_Wait_Times_Based_On_Num_Of_Priorities(num_of_priorities):\n",
+    "    return P_GROUP_WAITING_TIMES.get(num_of_priorities)\n",
+    "\n",
+    "P_GROUP_WAITING_TIMES = initialise_values(dataFrame, P_GROUP_BLOCK_INTERVAL_DICTIONARY)\n",
+    "print(\"Wait Times For 2 Priority Groups:\", Get_Wait_Times_Based_On_Num_Of_Priorities(4))"
    ]
   }
  ],

--- a/Wait_Times_Math_Model/estimating_waiting_time.py
+++ b/Wait_Times_Math_Model/estimating_waiting_time.py
@@ -1,0 +1,102 @@
+import pandas
+from scipy.optimize import newton
+
+P_GROUP_SIZE = 2
+P_GROUP_BLOCK_INTERVAL_DICTIONARY = {
+    2 : [1],
+    4 : [1,3,10],
+    6 : [1,2,4,8,23],
+    8 : [1,2,4,7,13,23,50]
+}
+
+def calculate_feerate_for_priority_groups(data, upper_boundary):
+    feerate_range = []
+    transaction_counts = 0
+    feerate_range.append(data['fee_rate'].max())
+    for i in range(len(upper_boundary)):
+        transaction_counts = len(data[data['no_block_confirm'] <= upper_boundary[i]])
+        boundary = data['fee_rate'].tail(transaction_counts).iloc[0]
+        feerate_range.append(boundary)
+    feerate_range.append(0.0)
+    return feerate_range
+
+def calculate_lambda_for_priority_groups(data, feerate_range):
+    p_groups_lambda = []
+    received_time_max = data['received_time'].max()
+    received_time_min = data['received_time'].min()
+    for current, next in zip(feerate_range,feerate_range[1:]):
+        p_df = data[(data['fee_rate'] <= current) & (data['fee_rate'] > next)]
+        p_transaction_count = len(p_df)
+        p_lambda = float(p_transaction_count) / (received_time_max - received_time_min)
+        p_groups_lambda.append(p_lambda)
+    return p_groups_lambda
+
+def NewtonMethod(lam, m_u, block_size, x0, epsilon):
+    fx = lambda x: lam*(1 - x) - m_u*x*(1 - x**block_size)
+    dfx = lambda x: m_u*(block_size*x**block_size + x**block_size - 1) - lam
+    while True:
+        x1 = x0 - fx(x0) / dfx(x0)
+        t = abs(x1 - x0)
+        if t < epsilon:
+            break
+        x0 = x1
+    return x0
+
+def SciPyNewton(lam, m_u, block_size, x0, epsilon, max_iteration):
+    fx = lambda x: lam*(1 - x) - m_u*x*(1 - x**block_size)
+    #dfx = lambda x: m_u*(block_size*x**block_size + x**block_size - 1) - lam
+    #return newton(fx, x0, fprime=dfx, args=(), tol=epsilon, maxiter=max_iteration, fprime2=None)
+    return newton(fx, x0, fprime=None, args=(), tol=epsilon, maxiter=max_iteration, fprime2=None)
+
+def calculate_z_priority(lambda_priority_group, mu, mean_block_size):
+    my_p_group_z = []
+    sciPy_p_group_z = []
+    lambda_sum = 0.0
+    for i in range(len(lambda_priority_group)):
+        lambda_sum += lambda_priority_group[i]
+        my_p_group_z.append(NewtonMethod(lambda_sum, mu, mean_block_size, 0, 1e-10))
+        sciPy_p_group_z.append(SciPyNewton(lambda_sum, mu, mean_block_size, 0, 1e-10, 500))
+    #return my_p_group_z
+    return sciPy_p_group_z
+
+def calculate_wait_time_for_priority_groups(p_group_lambda, p_group_z):
+    prev_transaction_in_queue = 0.0
+    p_group_response_time = []
+    for i in range(len(p_group_lambda)):
+        temp = p_group_z[i] / (1 - p_group_z[i])
+        transaction_in_queue = temp - prev_transaction_in_queue
+        prev_transaction_in_queue = temp
+        response_time = transaction_in_queue / p_group_lambda[i]
+        p_group_response_time.append(response_time)
+    return p_group_response_time
+
+class EstimatingWaitingTime:
+    P_GROUP_WAITING_TIMES = {}
+
+    try:
+        COLS_TO_USE = [4,5,6,9,10,12,13,14,15,16]
+        HEADER_NAMES = ['size','weight','received_time','fee','confirmed_block_height','confirm_time','waiting_time','fee_rate','enter_block_height','no_block_confirm']
+        d1 = pandas.read_csv('TimetxinBlock621500.csv', usecols=COLS_TO_USE, names=HEADER_NAMES)
+        d2 = pandas.read_csv('TimetxinBlock622000.csv', usecols=COLS_TO_USE, names=HEADER_NAMES)
+        d3 = pandas.read_csv('TimetxinBlock622500.csv', usecols=COLS_TO_USE, names=HEADER_NAMES)
+        dataFrame = pandas.concat([d1, d2, d3])
+
+        dataFrame = dataFrame[dataFrame['waiting_time'] >= 0] # Remove any rows with negative values for waiting_time
+
+        block_groups = dataFrame.groupby(['confirmed_block_height'])['confirmed_block_height'].count()
+        mean_block_size = float(round(block_groups.mean()))
+        service_time = 600
+        mu = 1/service_time
+
+        for key, value in P_GROUP_BLOCK_INTERVAL_DICTIONARY.items():
+            feerate_range = calculate_feerate_for_priority_groups(dataFrame.sort_values('fee_rate'), value)
+            p_lambda = calculate_lambda_for_priority_groups(dataFrame, feerate_range)
+            p_z = calculate_z_priority(p_lambda, mu, mean_block_size)
+            p_wait_time = calculate_wait_time_for_priority_groups(p_lambda, p_z)
+            P_GROUP_WAITING_TIMES[key] = p_wait_time
+
+        #print("Wait Times For 4 Priority Groups:", P_GROUP_WAITING_TIMES.get(4))
+
+    except :
+        print("No data in transaction relation")
+                


### PR DESCRIPTION
- Changed code to first calculate all priority groups we currently have based on the block interval data provided by Rui
- Added a function to retrieve wait times for a particular number of priority groups
- Added in plain/raw python file called "estimating_waiting_times.py" similar to the file already added in the backend file, just with data loading added in, this file is based on the jupyter notebook file (QueueWaitTimes.ipynb)